### PR TITLE
Adds Squad2 class to manually download parquet 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,207 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+
+playground*.ipynb
+data/*

--- a/recipe/abstention_datasets/squad.py
+++ b/recipe/abstention_datasets/squad.py
@@ -7,6 +7,10 @@ LICENSE file in the root directory of this source tree.
 import datasets
 from recipe.abstention_datasets.abstract_abstention_dataset import AbstentionDataset
 from recipe.abstention_datasets.abstract_abstention_dataset import Prompt
+from pathlib import Path
+import pandas as pd
+import urllib.request
+
 
 
 class Squad2Dataset(AbstentionDataset):
@@ -17,11 +21,29 @@ class Squad2Dataset(AbstentionDataset):
     def __init__(self, max_num_samples=None):
         super().__init__()
 
-        self.dataset = datasets.load_dataset(
-            "rajpurkar/squad_v2",
-        )["validation"]
-
+        self.dataset = self.load_dataset()
         self.max_num_samples = max_num_samples
+
+    def load_dataset(self) -> datasets.Dataset:
+        repo_dir = Path(__file__).absolute().parent.parent.parent
+        print(repo_dir)
+        data_path =  repo_dir / Path("data/squad2_validation.parquet")
+        # download
+        if not data_path.exists():
+            self.download(data_path)
+        df = pd.read_parquet(data_path)
+        df_dict = df.to_dict("list")
+        dataset = datasets.Dataset.from_dict(df_dict)
+        return dataset
+
+    def download(self, data_path: Path):
+        url = "https://huggingface.co/datasets/rajpurkar/squad_v2/resolve/main/squad_v2/validation-00000-of-00001.parquet"
+        try:
+            urllib.request.urlretrieve(url, data_path)
+        except Exception as e:
+            print(f"Failed to download dataset from {url}."
+                  f" Download it squad 2 validation parquet to {data_path} manually.")
+            raise e
 
     def __len__(self):
         return self.max_num_samples or len(self.dataset)
@@ -49,3 +71,10 @@ class Squad2Dataset(AbstentionDataset):
             should_abstain=should_abstain,
             metadata=metadata,
         )
+
+
+if __name__ == "__main__":
+    dataset = Squad2Dataset(max_num_samples=3)
+    for i in range(len(dataset)):
+        print(dataset[i])
+        print()


### PR DESCRIPTION
Fixes bug in squad2 huggingface dataset by manually parsing the parquet file using pandas

- adds gitignore 
- tested with `python recipe/abstention_datasets/squad.py`
- uses `data/` as a cache dir 
- returns a standard HuggingFace Dataset class